### PR TITLE
ensure art pr's don't repeat messages when they're not supposed to

### DIFF
--- a/lib/lita/github_pr_list/status.rb
+++ b/lib/lita/github_pr_list/status.rb
@@ -41,7 +41,8 @@ module Lita
       end
 
       def update(new_comment)
-        self.status[:last_comment] = parse_dev(new_comment) unless self.dev.nil?
+        self.status[:last_comment] = ""
+        self.status[:last_comment] += parse_dev(new_comment) unless self.dev.nil?
         self.status[:last_comment] += parse_design(new_comment) unless self.design.nil?
         self.status[:last_comment] += parse_common(new_comment)
         self.comment = new_comment

--- a/lib/lita/github_pr_list/version.rb
+++ b/lib/lita/github_pr_list/version.rb
@@ -1,5 +1,5 @@
 module Lita
   module GithubPrList
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/lita/handlers/comment_hook_spec.rb
+++ b/spec/lita/handlers/comment_hook_spec.rb
@@ -145,7 +145,7 @@ describe Lita::Handlers::GithubPrList, lita_handler: true do
   it "it says nothing" do
     expect_any_instance_of(Octokit::Client).to receive(:issue_comments).and_return(issue_comments_trivial)
 
-    request = Rack::Request.new("rack.input" => StringIO.new(issue_comment_event_passed_dev_context))
+    request = Rack::Request.new("rack.input" => StringIO.new(issue_comment_event_passed_design_context))
     response = Rack::Response.new(['Hello'], 200, { 'Content-Type' => 'text/plain' })
 
     github_handler = Lita::Handlers::GithubPrList.new robot


### PR DESCRIPTION
Had to make one more change to ensure the use of :art: design review wouldn't cause repeat messages