### PR TITLE
Adding username of person who opened the pull request

### DIFF
--- a/lib/lita/github_pr_list/pull_request.rb
+++ b/lib/lita/github_pr_list/pull_request.rb
@@ -35,7 +35,7 @@ module Lita
       def build_summary
         github_pull_requests.map do |pr_issue|
           status = repo_status("#{pr_issue.repository.full_name}", pr_issue)
-          "#{pr_issue.repository.name} #{status} #{pr_issue.title} #{pr_issue.pull_request.html_url}"
+          "#{pr_issue.repository.name} #{status} #{pr_issue.title} #{pr_issue.pull_request.html_url} (#{pr_opener pr_issue})"
         end
       end
 
@@ -51,6 +51,10 @@ module Lita
       def comments(repo_full_name, issue_number, options = nil)
         github_options = options || { direction: 'asc', sort: 'created' }
         github_client.issue_comments(repo_full_name, issue_number, github_options)
+      end
+
+      def pr_opener(pr)
+        pr.user.nil? ? 'unknown' : pr.user.login
       end
     end
   end

--- a/lib/lita/github_pr_list/version.rb
+++ b/lib/lita/github_pr_list/version.rb
@@ -1,5 +1,5 @@
 module Lita
   module GithubPrList
-    VERSION = "0.2.2"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/lita/handlers/pull_request_spec.rb
+++ b/spec/lita/handlers/pull_request_spec.rb
@@ -51,10 +51,9 @@ describe Lita::Handlers::GithubPrList, lita_handler: true do
     expect_any_instance_of(Octokit::Client).to receive(:issue_comments).and_return(issue_comments_passed, issue_comments_failed, issue_comments_passed_design)
 
     send_command("pr list")
-
-    expect(replies.last).to include("waffles (elephant)(art)(art)(art) Found a waffle https://github.com/octocat/Hello-World/pull/1347")
-    expect(replies.last).to include("waffles (elephant)(elephant)(elephant)(art) Found a bug https://github.com/octocat/Hello-World/pull/1347")
-    expect(replies.last).to include("waffles (poop)(elephant)(art) Found a waffle https://github.com/octocat/Hello-World/pull/1347")
+    expect(replies.last).to include("waffles (elephant)(art)(art)(art) Found a waffle https://github.com/octocat/Hello-World/pull/1347 (octocat)")
+    expect(replies.last).to include("waffles (elephant)(elephant)(elephant)(art) Found a bug https://github.com/octocat/Hello-World/pull/1347 (octocat)")
+    expect(replies.last).to include("waffles (poop)(elephant)(art) Found a waffle https://github.com/octocat/Hello-World/pull/1347 (octocat)")
   end
 
   it "displays the status of the PR (in review/fixed)" do
@@ -62,8 +61,8 @@ describe Lita::Handlers::GithubPrList, lita_handler: true do
     expect_any_instance_of(Octokit::Client).to receive(:issue_comments).and_return(issue_comments_in_review, issue_comments_fixed)
 
     send_command("pr list")
-    expect(replies.last).to include("waffles (book)(elephant)(art) Found a bug https://github.com/octocat/Hello-World/pull/1347")
-    expect(replies.last).to include("waffles (wave)(elephant)(art) Found a waffle https://github.com/octocat/Hello-World/pull/1347")
+    expect(replies.last).to include("waffles (book)(elephant)(art) Found a bug https://github.com/octocat/Hello-World/pull/1347 (octocat)")
+    expect(replies.last).to include("waffles (wave)(elephant)(art) Found a waffle https://github.com/octocat/Hello-World/pull/1347 (octocat)")
   end
 
   it "displays the status of the PR (new)" do
@@ -72,7 +71,7 @@ describe Lita::Handlers::GithubPrList, lita_handler: true do
 
     send_command("pr list")
 
-    expect(replies.last).to include("waffles (new)(elephant)(art) Found a bug https://github.com/octocat/Hello-World/pull/1347")
+    expect(replies.last).to include("waffles (new)(elephant)(art) Found a bug https://github.com/octocat/Hello-World/pull/1347 (octocat)")
   end
 
   it "lists gitlab merge requests" do


### PR DESCRIPTION
- Gitlab would require adding in a direct API call, since its webhook only returns the user ID, not name. It's already flaky enough, being unable to properly clear out closed merge requests via webhooks... 🗑 

🐘 