### PR TITLE
Use the comment body that is posted to determine lita messages

### DIFF
--- a/lib/lita/github_pr_list/comment_hook.rb
+++ b/lib/lita/github_pr_list/comment_hook.rb
@@ -25,7 +25,7 @@ module Lita
 
       def message
         self.status = repo_status(payload["repository"]["full_name"], payload["issue"])
-        if !issue_body.empty?
+        if issue_body.present?
           if issue_body.match Lita::GithubPrList::Status::REVIEW_REGEX
             "@#{commenter} is currently reviewing: #{issue_title}. #{issue_html_url}, @#{commenter}++"
           elsif issue_body.match Lita::GithubPrList::Status::FAIL_REGEX
@@ -44,11 +44,11 @@ module Lita
 
     private
       def pass_dev?
-        if self.status[:list].include? Lita::GithubPrList::Status::PASS_DESIGN_EMOJI
+        if status[:list].include? Lita::GithubPrList::Status::PASS_DESIGN_EMOJI
           "@#{issue_owner} your pull request: #{issue_title} has passed. #{issue_html_url}"
         else
           resp = "@#{issue_owner} your pull request: #{issue_title} has passed DEV REVIEW. #{issue_html_url}"
-          if self.status[:list].include?(Lita::GithubPrList::Status::DESIGN_REVIEW_REQUIRED) && !status[:list].include?(Lita::GithubPrList::Status::PASS_DESIGN_EMOJI)
+          if status[:list].include?(Lita::GithubPrList::Status::DESIGN_REVIEW_REQUIRED) && !status[:list].include?(Lita::GithubPrList::Status::PASS_DESIGN_EMOJI)
             resp += " - You still require DESIGN REVIEW"
           end
           resp
@@ -57,7 +57,7 @@ module Lita
 
       def pass_design?
         resp = "@#{issue_owner} your pull request: #{issue_title} has passed DESIGN. #{issue_html_url}"
-        if self.status[:list].include?(Lita::GithubPrList::Status::DEV_REVIEW_REQUIRED) && !status[:list].match(Lita::GithubPrList::Status::PASS_DEV_EMOJI)
+        if status[:list].include?(Lita::GithubPrList::Status::DEV_REVIEW_REQUIRED) && !status[:list].match(Lita::GithubPrList::Status::PASS_DEV_EMOJI)
           resp += " - You still require DEV REVIEW"
         end
         resp

--- a/lib/lita/github_pr_list/comment_hook.rb
+++ b/lib/lita/github_pr_list/comment_hook.rb
@@ -25,12 +25,12 @@ module Lita
 
       def message
         self.status = repo_status(payload["repository"]["full_name"], payload["issue"])
-        if !status[:last_comment].empty?
-          if status[:last_comment].include? Lita::GithubPrList::Status::REVIEW_EMOJI
+        if !issue_body.empty?
+          if issue_body.match Lita::GithubPrList::Status::REVIEW_REGEX
             "@#{commenter} is currently reviewing: #{issue_title}. #{issue_html_url}, @#{commenter}++"
-          elsif status[:last_comment].include? Lita::GithubPrList::Status::FAIL_EMOJI
+          elsif issue_body.match Lita::GithubPrList::Status::FAIL_REGEX
             "@#{issue_owner} your pull request: #{issue_title} has failed. #{issue_html_url}"
-          elsif status[:last_comment].include? Lita::GithubPrList::Status::FIXED_EMOJI
+          elsif issue_body.match Lita::GithubPrList::Status::FIXED_REGEX
             "#{issue_title} has been fixed: #{issue_html_url}"
           elsif status[:list].include? Lita::GithubPrList::Status::PASS_DEV_EMOJI
             pass_dev?

--- a/lib/lita/github_pr_list/comment_hook.rb
+++ b/lib/lita/github_pr_list/comment_hook.rb
@@ -1,8 +1,8 @@
 module Lita
   module GithubPrList
     class CommentHook
-      attr_accessor :request, :response, :payload, :commenter, :issue_owner, :issue_title, :issue_body, :status,
-                    :issue_html_url, :redis, :github_organization, :github_client
+      attr_accessor :request, :response, :payload, :commenter, :issue_owner, :issue_title, :issue_body,
+                    :status, :comment_body, :issue_html_url, :redis, :github_organization, :github_client
 
       def initialize(params = {})
         self.response = params.fetch(:response, nil)
@@ -20,21 +20,22 @@ module Lita
         self.issue_owner = redis.get("alias:#{payload["issue"]["user"]["login"]}") || payload["issue"]["user"]["login"]
         self.issue_title = payload["issue"]["title"]
         self.issue_html_url = payload["issue"]["html_url"]
-        self.issue_body = payload["comment"]["body"]
+        self.issue_body = payload["issue"]["body"]
+        self.comment_body = payload["comment"]["body"]
       end
 
       def message
         self.status = repo_status(payload["repository"]["full_name"], payload["issue"])
-        if issue_body.present?
-          if issue_body.match Lita::GithubPrList::Status::REVIEW_REGEX
+        if !comment_body.empty?
+          if comment_body.match Lita::GithubPrList::Status::REVIEW_REGEX
             "@#{commenter} is currently reviewing: #{issue_title}. #{issue_html_url}, @#{commenter}++"
-          elsif issue_body.match Lita::GithubPrList::Status::FAIL_REGEX
+          elsif comment_body.match Lita::GithubPrList::Status::FAIL_REGEX
             "@#{issue_owner} your pull request: #{issue_title} has failed. #{issue_html_url}"
-          elsif issue_body.match Lita::GithubPrList::Status::FIXED_REGEX
+          elsif comment_body.match Lita::GithubPrList::Status::FIXED_REGEX
             "#{issue_title} has been fixed: #{issue_html_url}"
-          elsif issue_body.match? Lita::GithubPrList::Status::PASS_DEV_REGEX
+          elsif comment_body.match Lita::GithubPrList::Status::PASS_DEV_REGEX
             pass_dev?
-          elsif issue_body.match? Lita::GithubPrList::Status::PASS_DESIGN_REGEX
+          elsif comment_body.match Lita::GithubPrList::Status::PASS_DESIGN_REGEX
             pass_design?
           end
         else
@@ -44,20 +45,16 @@ module Lita
 
     private
       def pass_dev?
-        if status[:list].include? Lita::GithubPrList::Status::PASS_DESIGN_EMOJI
-          "@#{issue_owner} your pull request: #{issue_title} has passed. #{issue_html_url}"
-        else
-          resp = "@#{issue_owner} your pull request: #{issue_title} has passed DEV REVIEW. #{issue_html_url}"
-          if status[:list].include?(Lita::GithubPrList::Status::DESIGN_REVIEW_REQUIRED) && !status[:list].include?(Lita::GithubPrList::Status::PASS_DESIGN_EMOJI)
-            resp += " - You still require DESIGN REVIEW"
-          end
-          resp
+        resp = "@#{issue_owner} your pull request: #{issue_title} has passed DEV REVIEW. #{issue_html_url}"
+        if issue_body.match(Lita::GithubPrList::Status::DESIGN_REVIEW_REGEX) && !status[:list].include?(Lita::GithubPrList::Status::PASS_DESIGN_EMOJI)
+          resp += " - You still require DESIGN REVIEW"
         end
+        resp
       end
 
       def pass_design?
         resp = "@#{issue_owner} your pull request: #{issue_title} has passed DESIGN. #{issue_html_url}"
-        if status[:list].include?(Lita::GithubPrList::Status::DEV_REVIEW_REQUIRED) && !status[:list].match(Lita::GithubPrList::Status::PASS_DEV_EMOJI)
+        if issue_body.match(Lita::GithubPrList::Status::DEV_REVIEW_REGEX) && !status[:list].include?(Lita::GithubPrList::Status::PASS_DEV_EMOJI)
           resp += " - You still require DEV REVIEW"
         end
         resp

--- a/lib/lita/github_pr_list/comment_hook.rb
+++ b/lib/lita/github_pr_list/comment_hook.rb
@@ -32,9 +32,9 @@ module Lita
             "@#{issue_owner} your pull request: #{issue_title} has failed. #{issue_html_url}"
           elsif issue_body.match Lita::GithubPrList::Status::FIXED_REGEX
             "#{issue_title} has been fixed: #{issue_html_url}"
-          elsif status[:list].include? Lita::GithubPrList::Status::PASS_DEV_EMOJI
+          elsif issue_body.match? Lita::GithubPrList::Status::PASS_DEV_REGEX
             pass_dev?
-          elsif status[:list].include? Lita::GithubPrList::Status::PASS_DESIGN_EMOJI
+          elsif issue_body.match? Lita::GithubPrList::Status::PASS_DESIGN_REGEX
             pass_design?
           end
         else

--- a/lib/lita/github_pr_list/version.rb
+++ b/lib/lita/github_pr_list/version.rb
@@ -1,5 +1,5 @@
 module Lita
   module GithubPrList
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end

--- a/spec/fixtures/design/issue_comment_event_passed.json
+++ b/spec/fixtures/design/issue_comment_event_passed.json
@@ -70,7 +70,7 @@
     },
     "created_at": "2014-07-01T17:21:15Z",
     "updated_at": "2014-07-01T17:21:15Z",
-    "body": "Passed :elephant: :elephant: :elephant:"
+    "body": "Passed :art: :art: :art:"
   },
   "repository": {
     "id": 20000106,

--- a/spec/fixtures/issue_comment_event_passed.json
+++ b/spec/fixtures/issue_comment_event_passed.json
@@ -42,7 +42,7 @@
     "created_at": "2014-07-01T17:21:15Z",
     "updated_at": "2014-07-01T17:21:15Z",
     "closed_at": null,
-    "body": "It looks like you accidently spelled 'commit' with two 't's."
+    "body": "It looks like you accidently spelled 'commit' with two 't's. :elephant: :art:"
   },
   "comment": {
     "url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments/47684681",

--- a/spec/fixtures/issue_comment_event_passed_design.json
+++ b/spec/fixtures/issue_comment_event_passed_design.json
@@ -42,7 +42,7 @@
     "created_at": "2014-07-01T17:21:15Z",
     "updated_at": "2014-07-01T17:21:15Z",
     "closed_at": null,
-    "body": "It looks like you accidently spelled 'commit' with two 't's."
+    "body": "It looks like you accidently spelled 'commit' with two 't's. :elephant: :art:"
   },
   "comment": {
     "url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments/47684681",
@@ -70,7 +70,7 @@
     },
     "created_at": "2014-07-01T17:21:15Z",
     "updated_at": "2014-07-01T17:21:15Z",
-    "body": "Passed DESIGN :art: :art: :art:"
+    "body": "Passed DESIGN :art::art::art:"
   },
   "repository": {
     "id": 20000106,

--- a/spec/fixtures/issue_comment_event_passed_emoji.json
+++ b/spec/fixtures/issue_comment_event_passed_emoji.json
@@ -42,7 +42,7 @@
     "created_at": "2014-07-01T17:21:15Z",
     "updated_at": "2014-07-01T17:21:15Z",
     "closed_at": null,
-    "body": "It looks like you accidently spelled 'commit' with two 't's."
+    "body": "It looks like you accidently spelled 'commit' with two 't's. :elephant: :art:"
   },
   "comment": {
     "url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments/47684681",

--- a/spec/lita/handlers/comment_hook_spec.rb
+++ b/spec/lita/handlers/comment_hook_spec.rb
@@ -108,23 +108,6 @@ describe Lita::Handlers::GithubPrList, lita_handler: true do
                                     " https://github.com/baxterthehacker/public-repo/issues/47")
     expect(replies.last).to_not include(" - You still require DEV REVIEW")
   end
-  context "Design/Dev passed and book is used" do
-    it "returns - currently reviewing" do
-      expect_any_instance_of(Octokit::Client).to receive(:issue_comments).and_return(issue_comments_passed_both_book_after)
-
-      request = Rack::Request.new("rack.input" => StringIO.new(issue_comment_event_passed_design))
-      response = Rack::Response.new(['Hello'], 200, { 'Content-Type' => 'text/plain' })
-
-      github_handler = Lita::Handlers::GithubPrList.new robot
-      github_handler.comment_hook(request, response)
-
-      expect(replies.last).to include("@baxterthehacker is currently reviewing: Spelling error in the README file."\
-                                      " https://github.com/baxterthehacker/public-repo/issues/47")
-      expect(replies.last).to_not include("@mcwaffle1234 your pull request: Spelling error in the README file has passed."\
-                                      " https://github.com/baxterthehacker/public-repo/issues/47")
-    end
-  end
-
 
   it "mentions the github user in the room and tell them they failed" do
     expect_any_instance_of(Octokit::Client).to receive(:issue_comments).and_return(issue_comments_failed)

--- a/spec/lita/handlers/comment_hook_spec.rb
+++ b/spec/lita/handlers/comment_hook_spec.rb
@@ -104,7 +104,7 @@ describe Lita::Handlers::GithubPrList, lita_handler: true do
     github_handler = Lita::Handlers::GithubPrList.new robot
     github_handler.comment_hook(request, response)
 
-    expect(replies.last).to include("@mcwaffle1234 your pull request: Spelling error in the README file has passed."\
+    expect(replies.last).to include("@mcwaffle1234 your pull request: Spelling error in the README file has passed DESIGN."\
                                     " https://github.com/baxterthehacker/public-repo/issues/47")
     expect(replies.last).to_not include(" - You still require DEV REVIEW")
   end
@@ -178,18 +178,6 @@ describe Lita::Handlers::GithubPrList, lita_handler: true do
 
     expect(replies.last).to include("Spelling error in the README file has been fixed:"\
                                     " https://github.com/baxterthehacker/public-repo/issues/47")
-  end
-
-  it "it says nothing" do
-    expect_any_instance_of(Octokit::Client).to receive(:issue_comments).and_return(issue_comments_trivial)
-
-    request = Rack::Request.new("rack.input" => StringIO.new(issue_comment_event_passed_design_context))
-    response = Rack::Response.new(['Hello'], 200, { 'Content-Type' => 'text/plain' })
-
-    github_handler = Lita::Handlers::GithubPrList.new robot
-    github_handler.comment_hook(request, response)
-
-    expect(replies.last).to eq(nil)
   end
 
   context "starting out with an initial elephant" do

--- a/spec/lita/handlers/comment_hook_spec.rb
+++ b/spec/lita/handlers/comment_hook_spec.rb
@@ -109,6 +109,24 @@ describe Lita::Handlers::GithubPrList, lita_handler: true do
     expect(replies.last).to_not include(" - You still require DEV REVIEW")
   end
 
+  context "Design/Dev passed and book is used" do
+    it "returns - currently reviewing" do
+      expect_any_instance_of(Octokit::Client).to receive(:issue_comments).and_return(issue_comments_passed_both_book_after)
+
+      request = Rack::Request.new("rack.input" => StringIO.new(issue_comment_event_in_review))
+      response = Rack::Response.new(['Hello'], 200, { 'Content-Type' => 'text/plain' })
+
+      github_handler = Lita::Handlers::GithubPrList.new robot
+      github_handler.comment_hook(request, response)
+
+      expect(replies.last).to include("@baxterthehacker is currently reviewing: Spelling error in the README file."\
+                                      " https://github.com/baxterthehacker/public-repo/issues/47,"\
+                                      " @baxterthehacker++")
+      expect(replies.last).to_not include("@mcwaffle1234 your pull request: Spelling error in the README file has passed."\
+                                      " https://github.com/baxterthehacker/public-repo/issues/47")
+    end
+  end
+
   it "mentions the github user in the room and tell them they failed" do
     expect_any_instance_of(Octokit::Client).to receive(:issue_comments).and_return(issue_comments_failed)
 


### PR DESCRIPTION
Addresses an issue where we may not actually get a message based off of the body of the comment that's passed to our comment processor.

The comment body itself should be the relevant piece of info.

:elephant: